### PR TITLE
fix TF2_IgnitePlayer

### DIFF
--- a/sourcemod/scripting/tf2c.sp
+++ b/sourcemod/scripting/tf2c.sp
@@ -97,9 +97,10 @@ public void OnPluginStart()
 		SetFailState("Gamedata \"tf2classic/addons/sourcemod/gamedata/tf2c.txt\" does not exist.");
 
 	// Burn
-	StartPrepSDKCall(SDKCall_Player);
+	StartPrepSDKCall(SDKCall_Raw);
 	PrepSDKCall_SetFromConf(conf, SDKConf_Signature, "Burn");
 	PrepSDKCall_AddParameter(SDKType_CBasePlayer, SDKPass_Pointer);
+	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer, VDECODE_FLAG_ALLOWNULL);
 	hIgnitePlayer = EndPrepSDKCall();
 	CHECK(hIgnitePlayer, "TF2_IgnitePlayer");
 
@@ -495,7 +496,7 @@ public any Native_TF2_IgnitePlayer(Handle plugin, int numParams)
 	if (!IsClientInGame(attacker))
 		return ThrowNativeError(SP_ERROR_NATIVE, "Attacker %d is not in-game.", attacker);
 
-	SDKCall(hIgnitePlayer, client, attacker);
+	SDKCall(hIgnitePlayer, GetEntityAddress(client) + view_as< Address >(FindSendPropInfo("CTFPlayer", "m_Shared")), attacker, -1);
 	return 0;
 }
 


### PR DESCRIPTION
Fixes #10

I've intentionally not committed the built plugin so that you might build it yourself instead to avoid security risks.

The primary problem was that the function is meant to be called on the player's shared state object, but the weapon parameter was also missing. The duration parameter has been omitted entirely as it appears TF2C does not provide one. Unfortunate!

The behavior of the standard extension is to pass the weapon parameter always as NULL, so I have replicated that behavior here.